### PR TITLE
Secondary weapon (handgun) on Key_7 for the sample keymap

### DIFF
--- a/keymap/gameforpeace.json
+++ b/keymap/gameforpeace.json
@@ -223,6 +223,16 @@
 			"switchMap": false
 		},
 		{
+			"comment": "手枪",
+			"type": "KMT_CLICK",
+			"key": "Key_7",
+			"pos": {
+				"x": 0.61,
+				"y": 0.82
+			},
+			"switchMap": false
+		},
+		{
 			"comment": "车加速",
 			"type": "KMT_CLICK",
 			"key": "Key_Shift",


### PR DESCRIPTION
Not sure if it's good to make this because:

- This is supposed to be on Key_3 but Key_3 was already occupied.
- When less than two primary weapons are available, secondary weapon shows at Key_1 or Key_2 position instead of its standard position.
- I'm taking the next available numeric key but Key_7 is supposed to be Med Kits.
- Key_7 for Med Kits can never be implemented because the coords of individual heal items aren't guaranteed (so aren't throwables).
