### PR TITLE
[compile] Replace QTimer::elapsed (deprecated) with QElapsedTimer

### DIFF
--- a/QtScrcpy/device/device.h
+++ b/QtScrcpy/device/device.h
@@ -1,6 +1,7 @@
 #ifndef DEVICE_H
 #define DEVICE_H
 
+#include <QElapsedTimer>
 #include <QPointer>
 #include <QTime>
 
@@ -116,7 +117,7 @@ private:
     // ui
     QPointer<VideoForm> m_videoForm;
 
-    QTime m_startTimeCount;
+    QElapsedTimer m_startTimeCount;
     DeviceParams m_params;
 
     GroupControlState m_controlState = GCS_FREE;


### PR DESCRIPTION
With Qt 5.14.2 strict compilation failed because QTimer::elapsed is deprecated.