### PR TITLE
Enhance speedRatio setting and allow individual axis values (#270 #290)

### DIFF
--- a/QtScrcpy/device/controller/inputconvert/inputconvertgame.cpp
+++ b/QtScrcpy/device/controller/inputconvert/inputconvertgame.cpp
@@ -395,8 +395,9 @@ bool InputConvertGame::processMouseMove(const QMouseEvent *from)
     }
 
     if (!m_ctrlMouseMove.lastPos.isNull() && m_processMouseMove) {
-        QPointF distance = from->localPos() - m_ctrlMouseMove.lastPos;
-        distance /= m_keyMap.getMouseMoveMap().data.mouseMove.speedRatio;
+        QPointF distance_raw{from->localPos() - m_ctrlMouseMove.lastPos};
+        QPointF speedRatio  {m_keyMap.getMouseMoveMap().data.mouseMove.speedRatio};
+        QPointF distance    {distance_raw.x() / speedRatio.x(), distance_raw.y() / speedRatio.y()};
 
         mouseMoveStartTouch(from);
         startMouseMoveTimer();

--- a/QtScrcpy/device/controller/inputconvert/keymap/keymap.cpp
+++ b/QtScrcpy/device/controller/inputconvert/keymap/keymap.cpp
@@ -64,11 +64,38 @@ void KeyMap::loadKeyMap(const QString &json)
         KeyMapNode keyMapNode;
         keyMapNode.type = KMT_MOUSE_MOVE;
 
-        if (!checkItemDouble(mouseMoveMap, "speedRatio")) {
-            errorString = QString("json error: mouseMoveMap on find speedRatio");
+        bool have_speedRatio = false;
+
+        // General speedRatio (for backwards compatibility)
+        if (checkItemDouble(mouseMoveMap, "speedRatio")) {
+            float ratio = static_cast<float>(getItemDouble(mouseMoveMap, "speedRatio"));
+            keyMapNode.data.mouseMove.speedRatio.setX(ratio);
+            keyMapNode.data.mouseMove.speedRatio.setY(ratio / 2.25f); // Phone screens are often FHD+
+            have_speedRatio = true;
+        }
+
+        // Individual X Ratio
+        if (checkItemDouble(mouseMoveMap, "speedRatioX")) {
+            keyMapNode.data.mouseMove.speedRatio.setX(static_cast<float>(getItemDouble(mouseMoveMap, "speedRatioX")));
+            have_speedRatio = true;
+        }
+
+        // Individual Y Ratio
+        if (checkItemDouble(mouseMoveMap, "speedRatioY")) {
+            keyMapNode.data.mouseMove.speedRatio.setY(static_cast<float>(getItemDouble(mouseMoveMap, "speedRatioY")));
+            have_speedRatio = true;
+        }
+
+        if (!have_speedRatio) {
+            errorString = QString("json error: speedRatio setting is missing in mouseMoveMap!");
             goto parseError;
         }
-        keyMapNode.data.mouseMove.speedRatio = static_cast<int>(getItemDouble(mouseMoveMap, "speedRatio"));
+
+        // Sanity check: No ratio must be lower than 0.001
+        if ( ( keyMapNode.data.mouseMove.speedRatio.x() < 0.001f ) || ( keyMapNode.data.mouseMove.speedRatio.x() < 0.001f ) ) {
+            errorString = QString("json error: Minimum speedRatio is 0.001");
+            goto parseError;
+        }
 
         if (!checkItemObject(mouseMoveMap, "startPos")) {
             errorString = QString("json error: mouseMoveMap on find startPos");

--- a/QtScrcpy/device/controller/inputconvert/keymap/keymap.h
+++ b/QtScrcpy/device/controller/inputconvert/keymap/keymap.h
@@ -91,8 +91,8 @@ public:
             } drag;
             struct
             {
-                QPointF startPos = { 0.0, 0.0 };
-                int speedRatio = 1;
+                QPointF startPos   = { 0.0, 0.0 };
+                QPointF speedRatio = { 1.0, 1.0 };
                 KeyNode smallEyes;
             } mouseMove;
             DATA() {}

--- a/docs/KeyMapDes.md
+++ b/docs/KeyMapDes.md
@@ -25,7 +25,9 @@ Taking the upper left corner of the screen as the origin, the position of the pi
 -mouseMoveMap: mouse movement mapping, the movement of the mouse will be mapped to startPos as the starting point, and the direction of the mouse movement as the direction of the finger drag operation (after the mouse movement map is turned on, the mouse will be hidden, limiting the range of mouse movement).
 Generally used to adjust the character field of vision in FPS mobile games.
     -startPos finger drag starting point
-    -speedRatio mouse movement is mapped to the ratio of finger dragging, you can control the mouse sensitivity, the value should be greater than 0.00, the greater the value, the lower the sensitivity
+    -speedRatio mouse sensitivity of the finger dragging. The value must be at least 0.00225. The greater the value, the lower the sensitivity. The Y-axis translates with a ratio of 2.25. If this does not fit your phone screen, please use the following two settings to set individual sensitivity values.
+    -speedRatioX sensitivity of the mouse X-axis. This value must be at least 0.001.
+    -speedRatioY sensitivity of the mouse Y-axis. This value must be at least 0.001.
     -smallEyes The button that triggers the small eyes. After pressing this button, the mouse movement will be mapped to the finger drag operation with the smallEyes.pos as the starting point and the mouse movement direction as the movement direction
 
 -keyMapNodes general key map, json array, all general key maps are placed in this array, map the keys of the keyboard to ordinary finger clicks.

--- a/keymap/FRAG.json
+++ b/keymap/FRAG.json
@@ -1,0 +1,119 @@
+{
+	"old-switchKey": "Key_QuoteLeft",
+	"switchKey": "RightButton",
+	"mouseMoveMap": {
+		"startPos": {
+			"x": 0.5,
+			"y": 0.5
+		},
+		"speedRatioX": 3.25,
+		"speedRatioY": 1.25
+	},
+	"keyMapNodes": [{
+			"comment": "Steering Wheel",
+			"type": "KMT_STEER_WHEEL",
+			"centerPos": {
+				"x": 0.194792,
+				"y": 0.716484
+			},
+			"leftOffset": 0.15,
+			"rightOffset": 0.15,
+			"upOffset": 0.15,
+			"downOffset": 0.15,
+			"leftKey": "Key_A",
+			"rightKey": "Key_D",
+			"upKey": "Key_W",
+			"downKey": "Key_S"
+		},
+		{
+			"comment": "Activate item under crosshair",
+			"type": "KMT_CLICK",
+			"key": "LeftButton",
+			"pos": {
+				"x": 0.51875,
+				"y": 0.496703
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Activate first special skill",
+			"type": "KMT_CLICK",
+			"key": "Key_E",
+			"pos": {
+				"x": 0.909375,
+				"y": 0.542857
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Activate Chat",
+			"type": "KMT_CLICK",
+			"key": "Key_C",
+			"pos": {
+				"x": 0.905208,
+				"y": 0.254945
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 1",
+			"type": "KMT_CLICK",
+			"key": "Key_1",
+			"pos": {
+				"x": 0.875,
+				"y": 0.523077
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 2",
+			"type": "KMT_CLICK",
+			"key": "Key_2",
+			"pos": {
+				"x": 0.875,
+				"y": 0.606593
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 3",
+			"type": "KMT_CLICK",
+			"key": "Key_3",
+			"pos": {
+				"x": 0.875,
+				"y": 0.685714
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 4",
+			"type": "KMT_CLICK",
+			"key": "Key_4",
+			"pos": {
+				"x": 0.875,
+				"y": 0.756044
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 5",
+			"type": "KMT_CLICK",
+			"key": "Key_5",
+			"pos": {
+				"x": 0.875,
+				"y": 0.832967
+			},
+			"switchMap": false
+		},
+		{
+			"comment": "Chat option 6",
+			"type": "KMT_CLICK",
+			"key": "Key_6",
+			"pos": {
+				"x": 0.875,
+				"y": 0.911273
+			},
+			"switchMap": false
+		}
+	]
+}


### PR DESCRIPTION
This commit changes the way the mouse sensitivity works as follows:

1. Turn speedRatio into a QPointF, so we have two floats instead of one integer.
2. Default the y-speedRatio to be x-speedRatio / 2.25, which takes the ultra-wideness of modern phone screens into account.
3. Add new configuration value speedRatioX to allow users to configure an individual X-ratio
4. Add new configuration value speedRatioY to allow users to configure an individual Y-ratio
5. Optimze distance-translation a bit.
6. Add keymaps/FRAG.json using new speedRatioX/speedRatioY for the game "FRAG! Pro Shooter"

Bug: #270
Bug: #290
