### PR TITLE
fix: don't show tray message twice

### DIFF
--- a/QtScrcpy/ui/dialog.cpp
+++ b/QtScrcpy/ui/dialog.cpp
@@ -272,9 +272,8 @@ void Dialog::slotActivated(QSystemTrayIcon::ActivationReason reason)
 void Dialog::closeEvent(QCloseEvent *event)
 {
     this->hide();
-    UserBootConfig config = Config::getInstance().getUserBootConfig();
-    if (!config.trayMessageShown) {
-        config.trayMessageShown = true;
+    if (!Config::getInstance().getTrayMessageShown()) {
+        Config::getInstance().setTrayMessageShown(true);
         m_hideIcon->showMessage(tr("Notice"),
                                 tr("Hidden here!"),
                                 QSystemTrayIcon::Information,

--- a/QtScrcpy/ui/dialog.cpp
+++ b/QtScrcpy/ui/dialog.cpp
@@ -272,10 +272,15 @@ void Dialog::slotActivated(QSystemTrayIcon::ActivationReason reason)
 void Dialog::closeEvent(QCloseEvent *event)
 {
     this->hide();
-    m_hideIcon->showMessage(tr("Notice"),
-                            tr("Hidden here!"),
-                            QSystemTrayIcon::Information,
-                            3000);
+    UserBootConfig config = Config::getInstance().getUserBootConfig();
+    if (!config.trayMessageShown) {
+        config.trayMessageShown = true;
+        m_hideIcon->showMessage(tr("Notice"),
+                                tr("Hidden here!"),
+                                QSystemTrayIcon::Information,
+                                3000);
+    }
+    Config::getInstance().setUserBootConfig(config);
     event->ignore();
 }
 

--- a/QtScrcpy/ui/dialog.cpp
+++ b/QtScrcpy/ui/dialog.cpp
@@ -279,7 +279,6 @@ void Dialog::closeEvent(QCloseEvent *event)
                                 QSystemTrayIcon::Information,
                                 3000);
     }
-    Config::getInstance().setUserBootConfig(config);
     event->ignore();
 }
 

--- a/QtScrcpy/util/config.cpp
+++ b/QtScrcpy/util/config.cpp
@@ -163,7 +163,6 @@ void Config::setUserBootConfig(const UserBootConfig &config)
     m_userData->setValue(COMMON_KEEP_ALIVE_KEY, config.keepAlive);
     m_userData->setValue(COMMON_SIMPLE_MODE_KEY, config.simpleMode);
     m_userData->setValue(COMMON_AUTO_UPDATE_DEVICE_KEY, config.autoUpdateDevice);
-    m_userData->setValue(COMMON_TRAY_MESSAGE_SHOWN_KEY, config.trayMessageShown);
     m_userData->endGroup();
     m_userData->sync();
 }
@@ -187,9 +186,25 @@ UserBootConfig Config::getUserBootConfig()
     config.keepAlive = m_userData->value(COMMON_KEEP_ALIVE_KEY, COMMON_KEEP_ALIVE_DEF).toBool();
     config.simpleMode = m_userData->value(COMMON_SIMPLE_MODE_KEY, COMMON_SIMPLE_MODE_DEF).toBool();
     config.autoUpdateDevice = m_userData->value(COMMON_AUTO_UPDATE_DEVICE_KEY, COMMON_AUTO_UPDATE_DEVICE_DEF).toBool();
-    config.trayMessageShown = m_userData->value(COMMON_TRAY_MESSAGE_SHOWN_KEY, COMMON_TRAY_MESSAGE_SHOWN_DEF).toBool();
     m_userData->endGroup();
     return config;
+}
+
+void Config::setTrayMessageShown(bool shown)
+{
+    m_userData->beginGroup(GROUP_COMMON);
+    m_userData->setValue(COMMON_TRAY_MESSAGE_SHOWN_KEY, shown);
+    m_userData->endGroup();
+    m_userData->sync();
+}
+
+bool Config::getTrayMessageShown()
+{
+    bool shown;
+    m_userData->beginGroup(GROUP_COMMON);
+    shown = m_userData->value(COMMON_TRAY_MESSAGE_SHOWN_KEY, COMMON_TRAY_MESSAGE_SHOWN_DEF).toBool();
+    m_userData->endGroup();
+    return shown;
 }
 
 void Config::setRect(const QString &serial, const QRect &rc)

--- a/QtScrcpy/util/config.cpp
+++ b/QtScrcpy/util/config.cpp
@@ -93,6 +93,9 @@
 #define COMMON_AUTO_UPDATE_DEVICE_KEY "AutoUpdateDevice"
 #define COMMON_AUTO_UPDATE_DEVICE_DEF true
 
+#define COMMON_TRAY_MESSAGE_SHOWN_KEY "TrayMessageShown"
+#define COMMON_TRAY_MESSAGE_SHOWN_DEF false
+
 // device config
 #define SERIAL_WINDOW_RECT_KEY_X "WindowRectX"
 #define SERIAL_WINDOW_RECT_KEY_Y "WindowRectY"
@@ -160,6 +163,7 @@ void Config::setUserBootConfig(const UserBootConfig &config)
     m_userData->setValue(COMMON_KEEP_ALIVE_KEY, config.keepAlive);
     m_userData->setValue(COMMON_SIMPLE_MODE_KEY, config.simpleMode);
     m_userData->setValue(COMMON_AUTO_UPDATE_DEVICE_KEY, config.autoUpdateDevice);
+    m_userData->setValue(COMMON_TRAY_MESSAGE_SHOWN_KEY, config.trayMessageShown);
     m_userData->endGroup();
     m_userData->sync();
 }
@@ -183,6 +187,7 @@ UserBootConfig Config::getUserBootConfig()
     config.keepAlive = m_userData->value(COMMON_KEEP_ALIVE_KEY, COMMON_KEEP_ALIVE_DEF).toBool();
     config.simpleMode = m_userData->value(COMMON_SIMPLE_MODE_KEY, COMMON_SIMPLE_MODE_DEF).toBool();
     config.autoUpdateDevice = m_userData->value(COMMON_AUTO_UPDATE_DEVICE_KEY, COMMON_AUTO_UPDATE_DEVICE_DEF).toBool();
+    config.trayMessageShown = m_userData->value(COMMON_TRAY_MESSAGE_SHOWN_KEY, COMMON_TRAY_MESSAGE_SHOWN_DEF).toBool();
     m_userData->endGroup();
     return config;
 }

--- a/QtScrcpy/util/config.h
+++ b/QtScrcpy/util/config.h
@@ -22,6 +22,7 @@ struct UserBootConfig
     bool keepAlive        = false;
     bool simpleMode       = false;
     bool autoUpdateDevice = true;
+    bool trayMessageShown = false;
 };
 
 class QSettings;

--- a/QtScrcpy/util/config.h
+++ b/QtScrcpy/util/config.h
@@ -22,7 +22,6 @@ struct UserBootConfig
     bool keepAlive        = false;
     bool simpleMode       = false;
     bool autoUpdateDevice = true;
-    bool trayMessageShown = false;
 };
 
 class QSettings;
@@ -51,6 +50,8 @@ public:
     // user data:common
     void setUserBootConfig(const UserBootConfig &config);
     UserBootConfig getUserBootConfig();
+    void setTrayMessageShown(bool shown);
+    bool getTrayMessageShown();
 
     // user data:device
     void setNickName(const QString &serial, const QString &name);


### PR DESCRIPTION
Don't show tray message every time the dialog closes, it's annoying.