### PR TITLE
fix: #1117 Fix phone window show blank if run with Qt6

### DIFF
--- a/QtScrcpy/render/qyuvopenglwidget.cpp
+++ b/QtScrcpy/render/qyuvopenglwidget.cpp
@@ -157,6 +157,8 @@ void QYUVOpenGLWidget::initializeGL()
 
 void QYUVOpenGLWidget::paintGL()
 {
+    m_shaderProgram.bind();
+
     if (m_needUpdate) {
         deInitTextures();
         initTextures();
@@ -175,6 +177,8 @@ void QYUVOpenGLWidget::paintGL()
 
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
+
+    m_shaderProgram.release();
 }
 
 void QYUVOpenGLWidget::resizeGL(int width, int height)


### PR DESCRIPTION
It needs to bind every time when GL paint on Qt6, and it works on Qt5 too.

Log: Fix phone window show blank if run with Qt6.