### PR TITLE
Clean up sndcpy.sh

### DIFF
--- a/QtScrcpy/sndcpy/sndcpy.sh
+++ b/QtScrcpy/sndcpy/sndcpy.sh
@@ -1,41 +1,39 @@
-#!/bin/bash
-
-echo Begin Runing...
-SNDCPY_PORT=28200
-SNDCPY_APK=sndcpy.apk
-ADB=./adb
+#!/usr/bin/env bash
+SNDCPY_PORT="28200"
+SNDCPY_APK="sndcpy.apk"
+ADB="./adb"
 
 serial=
 if [[ $# -ge 2 ]]
 then
     serial="-s $1"
-    SNDCPY_PORT=$2
+    SNDCPY_PORT="$2"
 fi
 
-echo "Waiting for device $1..."
-$ADB $serial wait-for-device
-echo "Find device $1"
+echo "Waiting for device '$1'..."
+"$ADB" "$serial" wait-for-device
+echo "Found device '$1'"
 
-sndcpy_installed=$($ADB $serial shell pm path com.rom1v.sndcpy)
+sndcpy_installed=$($ADB "$serial" shell pm path com.rom1v.sndcpy)
 if [[ $sndcpy_installed == "" ]]; then
-    echo Install $SNDCPY_APK... 
-    $ADB $serial uninstall com.rom1v.sndcpy || echo uninstall failed
-    $ADB $serial install -t -r -g $SNDCPY_APK
-    echo Install $SNDCPY_APK success
+    echo "Installing '$SNDCPY_APK'..." 
+    "$ADB" "$serial" uninstall com.rom1v.sndcpy || echo "Uninstall failed!"
+    "$ADB" "$serial" install -t -r -g "$SNDCPY_APK"
+    echo "Successfully installed '$SNDCPY_APK'"
 fi
 
-echo Request PROJECT_MEDIA permission...
-$ADB $serial shell appops set com.rom1v.sndcpy PROJECT_MEDIA allow
+echo "Requesting PROJECT_MEDIA permission..."
+"$ADB" "$serial" shell appops set com.rom1v.sndcpy PROJECT_MEDIA allow
 
-echo Forward port $SNDCPY_PORT...
-$ADB $serial forward tcp:$SNDCPY_PORT localabstract:sndcpy
+echo "Forwarding port $SNDCPY_PORT..."
+"$ADB" "$serial" forward "tcp:$SNDCPY_PORT" localabstract:sndcpy
 
-echo Start $SNDCPY_APK...
-$ADB $serial shell am start com.rom1v.sndcpy/.MainActivity
+echo "Starting '$SNDCPY_APK'..."
+"$ADB" "$serial" shell am start com.rom1v.sndcpy/.MainActivity
 
 while ((1))
 do
-    echo Waiting $SNDCPY_APK start...
+    echo "Waiting for '$SNDCPY_APK' to start..."
     sleep 0.1
     sndcpy_started=$($ADB shell 'ps | grep com.rom1v.sndcpy')
     if [[ $sndcpy_started != "" ]]; then
@@ -43,4 +41,4 @@ do
     fi
 done
 
-echo Ready playing...
+echo "Ready playing..."


### PR DESCRIPTION
Cleaned up `sndcpy.sh`, adding quotes to prevent word splitting, cleaned up English