### PR TITLE
feat: add clipboard button in the toolform

### DIFF
--- a/QtScrcpy/ui/toolform.cpp
+++ b/QtScrcpy/ui/toolform.cpp
@@ -52,6 +52,7 @@ void ToolForm::initStyle()
     IconHelper::Instance()->SetIcon(ui->screenShotBtn, QChar(0xf0c4), 15);
     IconHelper::Instance()->SetIcon(ui->touchBtn, QChar(0xf111), 15);
     IconHelper::Instance()->SetIcon(ui->groupControlBtn, QChar(0xf0c0), 15);
+    IconHelper::Instance()->SetIcon(ui->clipboardBtn, QChar(0xf0c5), 15);
 }
 
 void ToolForm::updateGroupControl()
@@ -230,4 +231,13 @@ void ToolForm::on_openScreenBtn_clicked()
         return;
     }
     device->setDisplayPower(true);
+}
+
+void ToolForm::on_clipboardBtn_clicked()
+{
+    auto device = qsc::IDeviceManage::getInstance().getDevice(m_serial);
+    if (!device) {
+        return;
+    }
+    device->requestDeviceClipboard();
 }

--- a/QtScrcpy/ui/toolform.h
+++ b/QtScrcpy/ui/toolform.h
@@ -47,6 +47,7 @@ private slots:
     void on_touchBtn_clicked();
     void on_groupControlBtn_clicked();
     void on_openScreenBtn_clicked();
+    void on_clipboardBtn_clicked();
 
 private:
     void initStyle();

--- a/QtScrcpy/ui/toolform.ui
+++ b/QtScrcpy/ui/toolform.ui
@@ -173,6 +173,16 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QPushButton" name="clipboardBtn">
+     <property name="toolTip">
+      <string>copy clipboard text</string>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+    </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
The Ctrl + C works, but I wanted to see it as a button. Helpful for first-time users. 