### PR TITLE
feat:Only allow a single instance; a second launch shows the running window

### DIFF
--- a/QtScrcpy/CMakeLists.txt
+++ b/QtScrcpy/CMakeLists.txt
@@ -204,6 +204,8 @@ set(QC_UTIL_SOURCES
     util/config.cpp
     util/mousetap/mousetap.h
     util/mousetap/mousetap.cpp
+    util/singleinstance.h
+    util/singleinstance.cpp
 )
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
     set(QC_UTIL_SOURCES ${QC_UTIL_SOURCES} 

--- a/QtScrcpy/main.cpp
+++ b/QtScrcpy/main.cpp
@@ -16,6 +16,7 @@
 #include "config.h"
 #include "dialog.h"
 #include "mousetap/mousetap.h"
+#include "singleinstance.h"
 
 static Dialog *g_mainDlg = Q_NULLPTR;
 static QtMessageHandler g_oldMessageHandler = Q_NULLPTR;
@@ -95,6 +96,14 @@ int main(int argc, char *argv[])
     g_oldMessageHandler = qInstallMessageHandler(myMessageOutput);
     QApplication a(argc, argv);
 
+    // Only one QtScrcpy per user. If one is already running (possibly hidden in
+    // the system tray), ask it to show its window and exit.
+    SingleInstance singleInstance(QStringLiteral("QtScrcpy"));
+    if (!singleInstance.isPrimary()) {
+        singleInstance.notifyPrimary();
+        return 0;
+    }
+
     // Set application icon for Linux (taskbar icon)
 #ifdef Q_OS_LINUX
     // Load icon from Qt resource (logo.png is included in res.qrc)
@@ -147,6 +156,7 @@ int main(int argc, char *argv[])
 
     g_mainDlg = new Dialog {};
     g_mainDlg->show();
+    QObject::connect(&singleInstance, &SingleInstance::activateRequested, g_mainDlg, &Dialog::bringToFront);
 
     qInfo() << QObject::tr("This software is completely open source and free. Use it at your own risk. You can download it at the "
             "following address:");

--- a/QtScrcpy/ui/dialog.cpp
+++ b/QtScrcpy/ui/dialog.cpp
@@ -563,6 +563,14 @@ void Dialog::slotActivated(QSystemTrayIcon::ActivationReason reason)
     }
 }
 
+void Dialog::bringToFront()
+{
+    show();
+    setWindowState((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive);
+    raise();
+    activateWindow();
+}
+
 void Dialog::closeEvent(QCloseEvent *event)
 {
     this->hide();

--- a/QtScrcpy/ui/dialog.h
+++ b/QtScrcpy/ui/dialog.h
@@ -37,6 +37,8 @@ public:
     void outLog(const QString &log, bool newLine = true);
     bool filterLog(const QString &log);
     void getIPbyIp();
+    // show the main window (e.g. when hidden in the tray) and give it focus
+    void bringToFront();
 
 private slots:
     void onDeviceConnected(bool success, const QString& serial, const QString& deviceName, const QSize& size);

--- a/QtScrcpy/util/singleinstance.cpp
+++ b/QtScrcpy/util/singleinstance.cpp
@@ -1,0 +1,108 @@
+#include <QDebug>
+#include <QLocalServer>
+#include <QLocalSocket>
+#ifdef Q_OS_WIN32
+#include <Windows.h>
+#endif
+
+#include "singleinstance.h"
+
+namespace
+{
+    const char kActivateMessage[] = "activate";
+    const int kTimeoutMs = 1000;
+
+    // The name becomes a named pipe on Windows and a file under /tmp elsewhere,
+    // so keep it to plain characters. Include the user name so two users on the
+    // same machine each get their own instance.
+    QString makeServerName(const QString &appId)
+    {
+        QString user = qEnvironmentVariable("USERNAME");
+        if (user.isEmpty()) {
+            user = qEnvironmentVariable("USER");
+        }
+        QString name = appId + "-" + user;
+        for (QChar &c : name) {
+            if (!c.isLetterOrNumber() && c != '-' && c != '_') {
+                c = '_';
+            }
+        }
+        return name;
+    }
+}
+
+SingleInstance::SingleInstance(const QString &appId, QObject *parent) : QObject(parent), m_serverName(makeServerName(appId))
+{
+    // Probe for a live primary. A stale socket file left by a crashed primary
+    // (Unix) refuses the connection, so a failed connect means we can take over.
+    QLocalSocket probe;
+    probe.connectToServer(m_serverName);
+    if (probe.waitForConnected(kTimeoutMs)) {
+        probe.disconnectFromServer();
+        m_primary = false;
+        return;
+    }
+
+    QLocalServer::removeServer(m_serverName);
+    m_server = new QLocalServer(this);
+    m_server->setSocketOptions(QLocalServer::UserAccessOption);
+    if (m_server->listen(m_serverName)) {
+        connect(m_server, &QLocalServer::newConnection, this, &SingleInstance::onNewConnection);
+    } else {
+        // Better to run unguarded than to refuse to start at all.
+        qWarning() << "SingleInstance: cannot listen on" << m_serverName << ":" << m_server->errorString();
+        delete m_server;
+        m_server = nullptr;
+    }
+    m_primary = true;
+}
+
+SingleInstance::~SingleInstance()
+{
+    if (m_server) {
+        m_server->close(); // also removes the socket file on Unix
+    }
+}
+
+bool SingleInstance::isPrimary() const
+{
+    return m_primary;
+}
+
+bool SingleInstance::notifyPrimary()
+{
+    QLocalSocket socket;
+    socket.connectToServer(m_serverName);
+    if (!socket.waitForConnected(kTimeoutMs)) {
+        qWarning() << "SingleInstance: cannot reach the running instance:" << socket.errorString();
+        return false;
+    }
+
+#ifdef Q_OS_WIN32
+    // This process was just launched by the user, so it holds the right to
+    // change the foreground window. Hand that right to the primary; without it
+    // Windows only flashes the taskbar button instead of raising the window.
+    AllowSetForegroundWindow(ASFW_ANY);
+#endif
+
+    socket.write(kActivateMessage);
+    socket.waitForBytesWritten(kTimeoutMs);
+    socket.disconnectFromServer();
+    if (socket.state() != QLocalSocket::UnconnectedState) {
+        socket.waitForDisconnected(kTimeoutMs);
+    }
+    return true;
+}
+
+void SingleInstance::onNewConnection()
+{
+    while (QLocalSocket *client = m_server->nextPendingConnection()) {
+        connect(client, &QLocalSocket::disconnected, client, &QLocalSocket::deleteLater);
+        connect(client, &QLocalSocket::readyRead, this, [this, client]() {
+            if (client->readAll().contains(kActivateMessage)) {
+                emit activateRequested();
+            }
+            client->disconnectFromServer();
+        });
+    }
+}

--- a/QtScrcpy/util/singleinstance.h
+++ b/QtScrcpy/util/singleinstance.h
@@ -1,0 +1,40 @@
+#ifndef SINGLEINSTANCE_H
+#define SINGLEINSTANCE_H
+
+#include <QObject>
+#include <QString>
+
+class QLocalServer;
+
+// Keeps a single QtScrcpy process per user.
+//
+// The first process becomes the primary and listens on a local socket. Any
+// process started later finds that socket, asks the primary to show its main
+// window (which may be hidden in the system tray) and then exits.
+class SingleInstance : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SingleInstance(const QString &appId, QObject *parent = nullptr);
+    ~SingleInstance() override;
+
+    // true when no other instance was found and this process now owns the lock
+    bool isPrimary() const;
+
+    // secondary instance only: ask the primary to show its window
+    bool notifyPrimary();
+
+signals:
+    // primary instance only: a secondary instance asked us to show the window
+    void activateRequested();
+
+private:
+    void onNewConnection();
+
+private:
+    QString m_serverName;
+    QLocalServer *m_server = nullptr;
+    bool m_primary = false;
+};
+
+#endif // SINGLEINSTANCE_H


### PR DESCRIPTION
The first process listens on a per-user local socket. Later launches ask it to show the main window (even when hidden in the tray) and exit.